### PR TITLE
python 3.7 no longer -dev, got released June 2018

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,14 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
-    - "3.7"
     - "pypy"
+
+matrix:
+    include:
+        - python: 3.7
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+
 install:
     - pip install tox-travis
 script:


### PR DESCRIPTION
needed workaround on travis