### PR TITLE
Update vagrant-provision.sh and dependency, plus project description logic in setup.py

### DIFF
--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,6 @@
+v1.1.5 Sun 30 Sep 2018
+  Update setup.py to show project description on pypi.org
+
 v1.1.4 Mon 19 Jul 2015
   Server response for exceeded quota is HTTP 402, not 429
 

--- a/demo.py
+++ b/demo.py
@@ -1,6 +1,4 @@
-import opencage
 from opencage.geocoder import OpenCageGeocode
-import json
 
 key = 'your-key-here'
 
@@ -8,4 +6,4 @@ geocoder = OpenCageGeocode(key)
 
 query = '182 Clerkenwell Road, London'
 ret = geocoder.geocode(query)
-print(ret._content)
+print ret._content

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,7 @@
 # -*- coding: utf-8 -*-
+
+# pylint: disable=redefined-builtin
+
 #
 # OpenCage Geocoder documentation build configuration file, created by
 # sphinx-quickstart on Sat Jun  7 14:38:18 2014.
@@ -187,22 +190,21 @@ htmlhelp_basename = 'OpenCageGeocoderdoc'
 # -- Options for LaTeX output ---------------------------------------------
 
 latex_elements = {
-# The paper size ('letterpaper' or 'a4paper').
-#'papersize': 'letterpaper',
+    # The paper size ('letterpaper' or 'a4paper').
+    #'papersize': 'letterpaper',
 
-# The font size ('10pt', '11pt' or '12pt').
-#'pointsize': '10pt',
+    # The font size ('10pt', '11pt' or '12pt').
+    #'pointsize': '10pt',
 
-# Additional stuff for the LaTeX preamble.
-#'preamble': '',
+    # Additional stuff for the LaTeX preamble.
+    #'preamble': '',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-  ('index', 'OpenCageGeocoder.tex', u'OpenCage Geocoder Documentation',
-   u'Rory McCann', 'manual'),
+    ('index', 'OpenCageGeocoder.tex', u'OpenCage Geocoder Documentation', u'Rory McCann', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -231,8 +233,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    ('index', 'opencagegeocoder', u'OpenCage Geocoder Documentation',
-     [u'Rory McCann'], 1)
+    ('index', 'opencagegeocoder', u'OpenCage Geocoder Documentation', [u'Rory McCann'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -245,9 +246,7 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-  ('index', 'OpenCageGeocoder', u'OpenCage Geocoder Documentation',
-   u'Rory McCann', 'OpenCageGeocoder', 'One line description of project.',
-   'Miscellaneous'),
+    ('index', 'OpenCageGeocoder', u'OpenCage Geocoder Documentation', u'Rory McCann', 'OpenCageGeocoder', 'One line description of project.', 'Miscellaneous'),
 ]
 
 # Documents to append as an appendix to all manuals.

--- a/flask_demo.py
+++ b/flask_demo.py
@@ -2,9 +2,9 @@
 #
 # Sample reverse geocode: http://127.0.0.1:5000/reverse/42.036488/-71.519678/
 import json
-from opencage.geocoder import OpenCageGeocode
 from flask import Flask
 from flask import request
+from opencage.geocoder import OpenCageGeocode
 
 app = Flask(__name__)
 _key = OPEN_CAGE_KEY = "db6a41dce5777db388d7dc348358690e"
@@ -12,15 +12,15 @@ _geocoder = OpenCageGeocode(OPEN_CAGE_KEY)
 
 @app.route("/forward/<address>")
 def forward(address):
-  verbose = json.loads(request.args.get('verbose', "false").lower()) 
-  raw_result = _geocoder.geocode(address)
-  return json.dumps(raw_result if verbose else [{"confidence": r["confidence"], "geometry": r["geometry"]} for r in raw_result if r["confidence"]])
+    verbose = json.loads(request.args.get('verbose', "false").lower())
+    raw_result = _geocoder.geocode(address)
+    return json.dumps(raw_result if verbose else [{"confidence": r["confidence"], "geometry": r["geometry"]} for r in raw_result if r["confidence"]])
 
 @app.route("/reverse/<lat>/<lng>/")
 def reverse(lat, lng):
-  verbose = json.loads(request.args.get('verbose', "false").lower())
-  raw_result = _geocoder.reverse_geocode(float(lat), float(lng))
-  return json.dumps(raw_result if verbose else [r["components"] for r in raw_result])
+    verbose = json.loads(request.args.get('verbose', "false").lower())
+    raw_result = _geocoder.reverse_geocode(float(lat), float(lng))
+    return json.dumps(raw_result if verbose else [r["components"] for r in raw_result])
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/opencage/geocoder.py
+++ b/opencage/geocoder.py
@@ -1,10 +1,11 @@
 """ Geocoder module. """
 
-import requests
-import collections
-import six
 from datetime import datetime
 from decimal import Decimal
+import collections
+
+import requests
+import six
 
 
 class OpenCageGeocodeError(Exception):
@@ -18,11 +19,12 @@ class InvalidInputError(OpenCageGeocodeError):
 
     """
     There was a problem with the input you provided.
-    
+
     :var bad_value: The value that caused the problem
     """
 
     def __init__(self, bad_value):
+        super(InvalidInputError, self).__init__()
         self.bad_value = bad_value
 
     def __unicode__(self):
@@ -49,6 +51,7 @@ class RateLimitExceededError(OpenCageGeocodeError):
 
     def __init__(self, reset_time, reset_to):
         """Constructor."""
+        super(RateLimitExceededError, self).__init__()
         self.reset_time = reset_time
         self.reset_to = reset_to
 
@@ -112,8 +115,8 @@ class OpenCageGeocode(object):
             'key': self.key
         }
         # Add user parameters
-        data.update(kwargs) 
-        
+        data.update(kwargs)
+
         url = self.url
         response = requests.get(url, params=data)
 
@@ -163,6 +166,10 @@ def _query_for_reverse_geocoding(lat, lng):
 
 
 def float_if_float(float_string):
+    """
+    Given a float string, returns the float value.
+    On value error returns the original string.
+    """
     try:
         float_val = float(float_string)
         return float_val

--- a/opencage/geocoder.py
+++ b/opencage/geocoder.py
@@ -4,9 +4,8 @@ from datetime import datetime
 from decimal import Decimal
 import collections
 
-import requests
 import six
-
+import requests
 
 class OpenCageGeocodeError(Exception):
 

--- a/pylintrc
+++ b/pylintrc
@@ -1,0 +1,554 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=
+
+# Use multiple processes to speed up Pylint.
+jobs=1
+
+# List of plugins (as comma separated values of python modules names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once).You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use"--disable=all --enable=classes
+# --disable=W"
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        invalid-unicode-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        locally-enabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        no-else-return,
+        missing-docstring,
+        invalid-name,
+        protected-access,
+        unpacking-non-sequence
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a note less than 10 (10 is the highest
+# note). You have access to the variables errors warning, statement which
+# respectively contain the number of errors / warnings messages and the total
+# number of statements analyzed. This is used by the global evaluation report
+# (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio).You can also give a reporter class, eg
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=optparse.Values,sys.exit
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it working
+# install python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to indicated private dictionary in
+# --spelling-private-dict-file option instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid to define new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expectedly
+# not used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,io,builtins
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis. It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging  or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=200
+
+# Maximum number of lines in a module
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[BASIC]
+
+# Naming style matching correct argument names
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style
+#argument-rgx=
+
+# Naming style matching correct attribute names
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style
+#class-attribute-rgx=
+
+# Naming style matching correct class names
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-style
+#class-rgx=
+
+# Naming style matching correct constant names
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style
+#inlinevar-rgx=
+
+# Naming style matching correct method names
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style
+#method-rgx=
+
+# Naming style matching correct module names
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style
+#variable-rgx=
+
+
+[LOGGING]
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format
+logging-modules=logging
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=mcs
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method
+max-args=5
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in a if statement
+max-bool-expr=5
+
+# Maximum number of branch for function / method body
+max-branches=12
+
+# Maximum number of locals for function / method body
+max-locals=15
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body
+max-returns=6
+
+# Maximum number of statements in function / method body
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=2
+
+
+[IMPORTS]
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma
+deprecated-modules=regsub,
+                   TERMIOS,
+                   Bastion,
+                   rexec
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled)
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled)
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled)
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "Exception"
+overgeneral-exceptions=Exception

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     test_suite='tests',
     tests_require=[
-        'httpretty',
+        'httpretty<=0.8.14',
         'six>=1.4.0',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ except FileNotFoundError:
 
 setup(
 	name="opencage",
-	version="1.1.4",
+	version="1.1.5",
 	description="Simple wrapper module for the OpenCage Geocoder API",
 	long_description=long_description,
 	long_description_content_type='text/markdown',
 	author="OpenCage Data Ltd",
 	author_email="info@opencagedata.com",
 	url="https://github.com/OpenCageData/python-opencage-geocoder/",
-    download_url="https://github.com/OpenCageData/python-opencage-geocoder/tarball/1.1.4",
+    download_url="https://github.com/OpenCageData/python-opencage-geocoder/tarball/1.1.5",
 	license="BSD",
 	packages=find_packages(),
 	include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,11 @@
 #/usr/bin/env python
 
-
-from setuptools import setup, find_packages
 import os
+from setuptools import setup, find_packages
 
 # if you are not using vagrant, just delete os.link directly,
 # The hard link only saves a little disk space, so you should not care
-if os.environ.get('USER','') == 'vagrant':
+if os.environ.get('USER', '') == 'vagrant':
     del os.link
 
 
@@ -27,22 +26,22 @@ except FileNotFoundError:
     long_description = ""
 
 setup(
-	name="opencage",
-	version="1.1.5",
-	description="Simple wrapper module for the OpenCage Geocoder API",
-	long_description=long_description,
-	long_description_content_type='text/markdown',
-	author="OpenCage Data Ltd",
-	author_email="info@opencagedata.com",
-	url="https://github.com/OpenCageData/python-opencage-geocoder/",
+    name="opencage",
+    version="1.1.5",
+    description="Simple wrapper module for the OpenCage Geocoder API",
+    long_description=long_description,
+    long_description_content_type='text/markdown',
+    author="OpenCage Data Ltd",
+    author_email="info@opencagedata.com",
+    url="https://github.com/OpenCageData/python-opencage-geocoder/",
     download_url="https://github.com/OpenCageData/python-opencage-geocoder/tarball/1.1.5",
-	license="BSD",
-	packages=find_packages(),
-	include_package_data=True,
-	zip_safe=False,
+    license="BSD",
+    packages=find_packages(),
+    include_package_data=True,
+    zip_safe=False,
     keywords=['geocoding', 'geocoder'],
-	classifiers=[
-		'Environment :: Web Environment',
+    classifiers=[
+        'Environment :: Web Environment',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -13,10 +13,25 @@ if os.environ.get('USER','') == 'vagrant':
 ROOT_DIR = os.path.dirname(__file__)
 SOURCE_DIR = os.path.join(ROOT_DIR)
 
+# try for pypy
+try:
+    FileNotFoundError
+except NameError:
+    FileNotFoundError = IOError
+
+# try for travis
+try:
+    with open(os.path.join(SOURCE_DIR, 'README.md')) as f:
+        long_description = f.read()
+except FileNotFoundError:
+    long_description = ""
+
 setup(
 	name="opencage",
 	version="1.1.4",
 	description="Simple wrapper module for the OpenCage Geocoder API",
+	long_description=long_description,
+	long_description_content_type='text/markdown',
 	author="OpenCage Data Ltd",
 	author_email="info@opencagedata.com",
 	url="https://github.com/OpenCageData/python-opencage-geocoder/",

--- a/tests.py
+++ b/tests.py
@@ -1,6 +1,10 @@
 # encoding: utf-8
+
+# pylint: disable=line-too-long
+# pylint: disable=anomalous-unicode-escape-in-string
+# pylint: disable=no-self-argument
+
 import unittest
-import re
 
 import six
 import httpretty
@@ -21,7 +25,8 @@ class OpenCageGeocodeTestCase(unittest.TestCase):
         httpretty.reset()
 
     def testUKPostcode(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"total_results":10,"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"status":{"message":"OK","code":200},"thanks":"For using an OpenCage Data API","rate":{"limit":"2500","remaining":2487,"reset":1402185600},"results":[{"annotations":{},"components":{"country_name":"United Kingdom","region":"Islington","locality":"Clerkenwell"},"formatted":"Clerkenwell, Islington, United Kingdom","geometry":{"lat":"51.5221558691","lng":"-0.100838524406"},"bounds":null},{"formatted":"82, Lokku Ltd, Clerkenwell Road, Clerkenwell, London Borough of Islington, London, EC1M 5RF, Greater London, England, United Kingdom, gb","components":{"county":"London","state_district":"Greater London","road":"Clerkenwell Road","country_code":"gb","house_number":"82","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","state":"England","house":"Lokku Ltd","postcode":"EC1M 5RF"},"annotations":{},"bounds":{"northeast":{"lng":"-0.1023889","lat":"51.5226795"},"southwest":{"lat":"51.5225795","lng":"-0.1024889"}},"geometry":{"lat":"51.5226295","lng":"-0.1024389"}},{"components":{"county":"London","state_district":"Greater London","road":"Clerkenwell Road","country_code":"gb","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","state":"England","postcode":"EC1M 6DS"},"annotations":{},"formatted":"Clerkenwell Road, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb","geometry":{"lat":"51.5225346","lng":"-0.1027003"},"bounds":{"northeast":{"lat":"51.5225759","lng":"-0.1020597"},"southwest":{"lat":"51.5225211","lng":"-0.103223"}}},{"formatted":"Clerkenwell Road, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb, Craft Central","annotations":{},"components":{"postcode":"EC1M 6DS","arts_centre":"Craft Central","state":"England","suburb":"Clerkenwell","country":"United Kingdom","city":"London Borough of Islington","country_code":"gb","road":"Clerkenwell Road","state_district":"Greater London","county":"London"},"bounds":{"northeast":{"lat":"51.52246","lng":"-0.1027652"},"southwest":{"lng":"-0.1028652","lat":"51.52236"}},"geometry":{"lng":"-0.1028152","lat":"51.52241"}},{"components":{"county":"London","state_district":"Greater London","restaurant":"Noodle Express","road":"Albemarle Way","country_code":"gb","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","state":"England","postcode":"EC1M 6DS"},"annotations":{},"formatted":"Noodle Express, Albemarle Way, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb","geometry":{"lng":"-0.10255386845056","lat":"51.5228195"},"bounds":{"southwest":{"lng":"-0.102621","lat":"51.5227781"},"northeast":{"lat":"51.5228603","lng":"-0.1024869"}}},{"geometry":{"lat":"51.5229424","lng":"-0.102380530769224"},"bounds":{"northeast":{"lat":"51.5229759","lng":"-0.1023064"},"southwest":{"lng":"-0.1024639","lat":"51.5229046"}},"annotations":{},"components":{"county":"London","state_district":"Greater London","road":"Albemarle Way","country_code":"gb","cafe":"PAR","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","state":"England","postcode":"EC1M 6DS"},"formatted":"PAR, Albemarle Way, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb"},{"formatted":"Workshop Coffee Co., 27, Clerkenwell Road, Clerkenwell, London Borough of Islington, London, EC1M 5RN, Greater London, England, United Kingdom, gb","components":{"county":"London","state_district":"Greater London","road":"Clerkenwell Road","country_code":"gb","house_number":"27","cafe":"Workshop Coffee Co.","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","state":"England","postcode":"EC1M 5RN"},"annotations":{},"bounds":{"southwest":{"lng":"-0.1024422","lat":"51.5222246"},"northeast":{"lng":"-0.1022307","lat":"51.5224408"}},"geometry":{"lat":"51.52234585","lng":"-0.102338899572156"}},{"components":{"county":"London","state_district":"Greater London","road":"St. John Street","country_code":"gb","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","hairdresser":"Franco & Co","state":"England","postcode":"EC1M 6DS"},"annotations":{},"formatted":"St. John Street, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb, Franco & Co","geometry":{"lng":"-0.1024118","lat":"51.5231165"},"bounds":{"southwest":{"lng":"-0.1024618","lat":"51.5230665"},"northeast":{"lng":"-0.1023618","lat":"51.5231665"}}},{"bounds":{"northeast":{"lng":"-0.1023218","lat":"51.5231688"},"southwest":{"lat":"51.5229634","lng":"-0.1024934"}},"geometry":{"lng":"-0.102399365567707","lat":"51.5230257"},"formatted":"St. John Street, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb, MacCarthy","annotations":{},"components":{"county":"London","state_district":"Greater London","road":"St. John Street","country_code":"gb","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","hairdresser":"MacCarthy","state":"England","postcode":"EC1M 6DS"}},{"geometry":{"lng":"-0.102730855172415","lat":"51.52267345"},"bounds":{"northeast":{"lng":"-0.1025498","lat":"51.5227315"},"southwest":{"lat":"51.5226068","lng":"-0.1028931"}},"annotations":{},"components":{"county":"London","state_district":"Greater London","road":"Albemarle Way","country_code":"gb","house_number":"84","country":"United Kingdom","city":"London Borough of Islington","suburb":"Clerkenwell","state":"England","house":"The Printworks","postcode":"EC1M 6DS"},"formatted":"84, The Printworks, Albemarle Way, Clerkenwell, London Borough of Islington, London, EC1M 6DS, Greater London, England, United Kingdom, gb"}],"timestamp":{"created_unix":1402133768,"created_http":"Sat, 07 Jun 2014 09:36:08 GMT"},"we_are_hiring":"http://lokku.com/#jobs"}',
         )
@@ -33,7 +38,8 @@ class OpenCageGeocodeTestCase(unittest.TestCase):
         )
 
     def testAustralia(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"licenses":[{"url":"http://creativecommons.org/licenses/by-sa/3.0/","name":"CC-BY-SA"},{"url":"http://opendatacommons.org/licenses/odbl/summary/","name":"ODbL"}],"status":{"message":"OK","code":200},"thanks":"For using an OpenCage Data API","results":[{"geometry":{"lng":"149.5886383","lat":"-32.5980702"},"components":{"country_code":"au","state":"New South Wales","country":"Australia","town":"Mudgee"},"formatted":"Mudgee, New South Wales, Australia, au","annotations":{},"bounds":{"southwest":{"lng":"149.5486383","lat":"-32.6380702"},"northeast":{"lng":"149.6286383","lat":"-32.5580702"}}},{"formatted":"Mudgee, Mid-Western Regional, New South Wales, Australia","components":{"state":"New South Wales","country":"Australia","county":"Mid-Western Regional","town":"Mudgee"},"bounds":{"southwest":{"lng":"149.573196411","lat":"-32.6093025208"},"northeast":{"lng":"149.602890015","lat":"-32.5818252563"}},"annotations":{},"geometry":{"lng":149.5871,"lat":-32.59426}}],"total_results":2,"rate":{"reset":1402185600,"limit":"2500","remaining":2489},"we_are_hiring":"http://lokku.com/#jobs","timestamp":{"created_http":"Sat, 07 Jun 2014 09:31:50 GMT","created_unix":1402133510}}',
         )
@@ -78,7 +84,8 @@ class OpenCageGeocodeTestCase(unittest.TestCase):
 
 
     def testMunster(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}],"thanks":"For using an OpenCage Data API","we_are_hiring":"http://lokku.com/#jobs","total_results":10,"status":{"message":"OK","code":200},"results":[{"formatted":"M\u00fcnster, M\u00fcnster, 48143,48144,48145,48146,48147,48148,48149,48150,48151,48152,48153,48154,48155,48156,48157,48158,48159,48160,48161,48162,48163,48164,48165,48166,48167, Regierungsbezirk M\u00fcnster, North Rhine-Westphalia, Germany, de","geometry":{"lat":"51.9625101","lng":"7.6251879"},"components":{"country_code":"de","postcode":"48143,48144,48145,48146,48147,48148,48149,48150,48151,48152,48153,48154,48155,48156,48157,48158,48159,48160,48161,48162,48163,48164,48165,48166,48167","state_district":"Regierungsbezirk M\u00fcnster","state":"North Rhine-Westphalia","city":"M\u00fcnster","county":"M\u00fcnster","country":"Germany"},"bounds":{"southwest":{"lng":"7.4651879","lat":"51.8025101"},"northeast":{"lng":"7.7851879","lat":"52.1225101"}},"annotations":{}},{"bounds":{"northeast":{"lat":"52.0600706","lng":"7.7743708"},"southwest":{"lat":"51.8402214","lng":"7.4738051"}},"annotations":{},"geometry":{"lat":"51.95027025","lng":"7.61334708872901"},"components":{"country_code":"de","state_district":"Regierungsbezirk M\u00fcnster","state":"North Rhine-Westphalia","county":"M\u00fcnster","country":"Germany"},"formatted":"M\u00fcnster, Regierungsbezirk M\u00fcnster, North Rhine-Westphalia, Germany, de"},{"formatted":"Munster, Ireland, ie","annotations":{},"bounds":{"southwest":{"lat":"51.4199027","lng":"-10.6891099"},"northeast":{"lng":"-6.9497829","lat":"53.1689062"}},"components":{"country_code":"ie","state_district":"Munster","country":"Ireland"},"geometry":{"lng":"-8.57089717629267","lat":"52.3076216"}},{"formatted":"Germany, de, M\u00fcnster","annotations":{},"bounds":{"southwest":{"lat":"51.8402214","lng":"7.4738051"},"northeast":{"lat":"52.0600706","lng":"7.7743708"}},"geometry":{"lat":"51.95027025","lng":"7.61334708872901"},"components":{"country_code":"de","address100":"M\u00fcnster","country":"Germany"}},{"formatted":"M\u00fcnster, M\u00fcnster, Stuttgart, Stuttgart, Regierungsbezirk Stuttgart, Baden-W\u00fcrttemberg, Germany, de","components":{"city":"Stuttgart","state":"Baden-W\u00fcrttemberg","city_district":"M\u00fcnster","country":"Germany","country_code":"de","state_district":"Regierungsbezirk Stuttgart","suburb":"M\u00fcnster","county":"Stuttgart"},"geometry":{"lat":"48.8212962","lng":"9.2200016"},"bounds":{"northeast":{"lng":"9.2400016","lat":"48.8412962"},"southwest":{"lng":"9.2000016","lat":"48.8012962"}},"annotations":{}},{"geometry":{"lng":"8.8671181","lat":"49.9229236"},"components":{"country_code":"de","state_district":"Regierungsbezirk Darmstadt","state":"Hesse","city":"M\u00fcnster","county":"Landkreis Darmstadt-Dieburg","country":"Germany"},"annotations":{},"bounds":{"northeast":{"lat":"49.9438725","lng":"8.9161067"},"southwest":{"lat":"49.9056973","lng":"8.7705856"}},"formatted":"M\u00fcnster, Landkreis Darmstadt-Dieburg, Regierungsbezirk Darmstadt, Hesse, Germany, de"},{"formatted":"M\u00fcnster, Stuttgart, Stuttgart, Regierungsbezirk Stuttgart, Baden-W\u00fcrttemberg, Germany, de","geometry":{"lat":"48.8272797","lng":"9.2024402537349"},"components":{"country_code":"de","state_district":"Regierungsbezirk Stuttgart","state":"Baden-W\u00fcrttemberg","city":"Stuttgart","city_district":"M\u00fcnster","county":"Stuttgart","country":"Germany"},"bounds":{"northeast":{"lat":"48.8384709","lng":"9.2273738"},"southwest":{"lng":"9.1883711","lat":"48.8152795"}},"annotations":{}},{"bounds":{"southwest":{"lng":"10.8788966","lat":"48.5896428"},"northeast":{"lat":"48.6515558","lng":"10.9314006"}},"annotations":{},"geometry":{"lng":"10.9008883","lat":"48.6242219"},"components":{"country_code":"de","state_district":"Swabia","state":"Free State of Bavaria","city":"M\u00fcnster","county":"Rain (Schwaben)","country":"Germany"},"formatted":"M\u00fcnster, Rain (Schwaben), Swabia, Free State of Bavaria, Germany, de"},{"formatted":"Munster, Lake County, Indiana, United States of America, us","bounds":{"northeast":{"lat":"41.5814003","lng":"-87.4802388"},"southwest":{"lng":"-87.5254509","lat":"41.522608"}},"annotations":{},"geometry":{"lat":"41.5644798","lng":"-87.5125412"},"components":{"country_code":"us","state":"Indiana","city":"Munster","county":"Lake County","country":"United States of America"}},{"bounds":{"northeast":{"lng":"12.5929086","lat":"48.9728073"},"southwest":{"lng":"12.5529086","lat":"48.9328073"}},"annotations":{},"geometry":{"lng":"12.5729086","lat":"48.9528073"},"components":{"country_code":"de","state_district":"Lower Bavaria","village":"M\u00fcnster","state":"Free State of Bavaria","county":"Landkreis Straubing-Bogen","country":"Germany"},"formatted":"M\u00fcnster, Landkreis Straubing-Bogen, Lower Bavaria, Free State of Bavaria, Germany, de"}],"timestamp":{"created_unix":1402135758,"created_http":"Sat, 07 Jun 2014 10:09:18 GMT"},"rate":{"remaining":2485,"reset":1402185600,"limit":"2500"}}',
         )
@@ -90,7 +97,8 @@ class OpenCageGeocodeTestCase(unittest.TestCase):
         )
 
     def testDonostia(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"thanks":"For using an OpenCage Data API","status":{"message":"OK","code":200},"rate":{"remaining":2482,"limit":"2500","reset":1402185600},"we_are_hiring":"http://lokku.com/#jobs","total_results":7,"results":[{"geometry":{"lat":"43.3213324","lng":"-1.9856227"},"annotations":{},"components":{"postcode":"20001;20002;20003;20004;20005;20006;20007;20008;20009;20010;20011;20012;20013;20014;20015;20016;20017;20018","county":"Donostialdea/Donostia-San Sebasti\u00e1n","state":"Basque Country","country":"Spain","city":"San Sebasti\u00e1n","country_code":"es"},"formatted":"San Sebasti\u00e1n, Donostialdea/Donostia-San Sebasti\u00e1n, 20001;20002;20003;20004;20005;20006;20007;20008;20009;20010;20011;20012;20013;20014;20015;20016;20017;20018, Basque Country, Spain, es","bounds":{"southwest":{"lat":"43.2178373","lng":"-2.086808"},"northeast":{"lng":"-1.8878838","lat":"43.3381344"}}},{"formatted":"Donostia, Irun, Bidasoa Beherea / Bajo Bidasoa, Basque Country, Spain, es","components":{"county":"Bidasoa Beherea / Bajo Bidasoa","state":"Basque Country","country":"Spain","city":"Irun","country_code":"es","road":"Donostia"},"bounds":{"southwest":{"lat":"43.3422299","lng":"-1.8022744"},"northeast":{"lng":"-1.8013452","lat":"43.3449598"}},"geometry":{"lng":"-1.8019153","lat":"43.3432784"},"annotations":{}},{"annotations":{},"geometry":{"lng":"-1.8022744","lat":"43.3422299"},"formatted":"Donostia, Anaka, Irun, Bidasoa Beherea / Bajo Bidasoa, Basque Country, Spain, es","components":{"county":"Bidasoa Beherea / Bajo Bidasoa","state":"Basque Country","country":"Spain","city":"Irun","suburb":"Anaka","country_code":"es","road":"Donostia"},"bounds":{"southwest":{"lng":"-1.8022971","lat":"43.3421635"},"northeast":{"lng":"-1.8022744","lat":"43.3422299"}}},{"geometry":{"lng":"-2.69312049872164","lat":"42.868297"},"annotations":{},"bounds":{"southwest":{"lng":"-2.6933154","lat":"42.8681484"},"northeast":{"lat":"42.8684357","lng":"-2.6929252"}},"formatted":"Donostia kalea, Ibaiondo, Vitoria-Gasteiz, Vitoria-Gasteizko Eskualdea / Cuadrilla de Vitoria, Basque Country, Spain, es","components":{"county":"Vitoria-Gasteizko Eskualdea / Cuadrilla de Vitoria","state":"Basque Country","country":"Spain","city":"Vitoria-Gasteiz","suburb":"Ibaiondo","country_code":"es","road":"Donostia kalea"}},{"bounds":{"southwest":{"lng":"-2.6889534","lat":"42.8620967"},"northeast":{"lat":"42.8623764","lng":"-2.6885774"}},"formatted":"Donostia kalea, Lakua, Vitoria-Gasteiz, Vitoria-Gasteizko Eskualdea / Cuadrilla de Vitoria, Basque Country, Spain, es","components":{"county":"Vitoria-Gasteizko Eskualdea / Cuadrilla de Vitoria","state":"Basque Country","country":"Spain","city":"Vitoria-Gasteiz","suburb":"Lakua","country_code":"es","road":"Donostia kalea"},"geometry":{"lat":"42.8622515","lng":"-2.68876582144679"},"annotations":{}},{"annotations":{},"geometry":{"lat":"51.5146888","lng":"-0.1609307"},"components":{"restaurant":"Donostia","country":"United Kingdom","state_district":"Greater London","country_code":"gb","county":"London","state":"England","suburb":"Marylebone","city":"City of Westminster","road":"Great Cumberland Mews"},"formatted":"Donostia, Great Cumberland Mews, Marylebone, City of Westminster, London, Greater London, England, United Kingdom, gb","bounds":{"northeast":{"lng":"-0.1608807","lat":"51.5147388"},"southwest":{"lat":"51.5146388","lng":"-0.1609807"}}},{"geometry":{"lat":43.31283,"lng":-1.97499},"annotations":{},"bounds":{"northeast":{"lng":"-1.92020404339","lat":"43.3401603699"},"southwest":{"lat":"43.2644081116","lng":"-2.04920697212"}},"formatted":"San Sebastian, Gipuzkoa, Basque Country, Spain, Donostia / San Sebasti\u00e1n","components":{"county":"Gipuzkoa","state":"Basque Country","country":"Spain","town":"San Sebastian","local administrative area":"Donostia / San Sebasti\u00e1n"}}],"timestamp":{"created_unix":1402136556,"created_http":"Sat, 07 Jun 2014 10:22:36 GMT"},"licenses":[{"name":"CC-BY-SA","url":"http://creativecommons.org/licenses/by-sa/3.0/"},{"name":"ODbL","url":"http://opendatacommons.org/licenses/odbl/summary/"}]}',
 
@@ -135,7 +143,8 @@ class RateLimitErrorTestCase(unittest.TestCase):
         httpretty.reset()
 
     def testNoRateLimit(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"status":{"code":200,"message":"OK"},"thanks":"For using an OpenCage Data API","total_results":0,"licenses":[{"url":"http://creativecommons.org/licenses/by-sa/3.0/","name":"CC-BY-SA"},{"url":"http://opendatacommons.org/licenses/odbl/summary/","name":"ODbL"}],"rate":{"reset":1402185600,"limit":"2500","remaining":2479},"results":[],"timestamp":{"created_http":"Sat, 07 Jun 2014 10:38:45 GMT","created_unix":1402137525}}')
 
@@ -144,7 +153,8 @@ class RateLimitErrorTestCase(unittest.TestCase):
 
 
     def testRateLimitExceeded(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"status":{"code":402,"message":"OK"},"thanks":"For using an OpenCage Data API","total_results":0,"licenses":[{"url":"http://creativecommons.org/licenses/by-sa/3.0/","name":"CC-BY-SA"},{"url":"http://opendatacommons.org/licenses/odbl/summary/","name":"ODbL"}],"rate":{"reset":1402185600,"limit":"2500","remaining":0},"results":[],"timestamp":{"created_http":"Sat, 07 Jun 2014 10:38:45 GMT","created_unix":1402137525}}',
             status=402,
@@ -189,7 +199,8 @@ class UnknownProblemTestCase(unittest.TestCase):
         httpretty.reset()
 
     def test500Status(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='',
             status=500,
@@ -198,7 +209,8 @@ class UnknownProblemTestCase(unittest.TestCase):
         self.assertRaises(UnknownError, self.geocoder.geocode, "whatever")
 
     def testNonJson(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='',
         )
@@ -206,7 +218,8 @@ class UnknownProblemTestCase(unittest.TestCase):
         self.assertRaises(UnknownError, self.geocoder.geocode, "whatever")
 
     def testNoResultsKey(self):
-        httpretty.register_uri(httpretty.GET,
+        httpretty.register_uri(
+            httpretty.GET,
             self.geocoder.url,
             body='{"spam": "eggs"}',
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py33, py34, pypy
 
 [testenv]
 commands = {envpython} setup.py test

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -7,7 +7,7 @@
 sudo apt-get update -qq
 sudo apt-get autoremove -y
 # sudo apt-get upgrade -y
-sudo apt-get install -y python-dev python-pip python3 python3.4 python2.7
+sudo apt-get install -y python-dev python-pip python3 python3.4 python2.7 pypy
 
 sudo pip install tox
 

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -7,7 +7,7 @@
 sudo apt-get update -qq
 sudo apt-get autoremove -y
 # sudo apt-get upgrade -y
-sudo apt-get install -y build-dep python-dev python-pip python3.2 python3.3 python2.6
+sudo apt-get install -y python-dev python-pip python3 python3.4 python2.7
 
 sudo pip install tox
 

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -5,7 +5,7 @@
 ## directory is '/root'
 
 sudo apt-get update -qq
-sudo apt-get apt-get autoremove -y
+sudo apt-get autoremove -y
 # sudo apt-get upgrade -y
 sudo apt-get install -y build-dep python-dev python-pip python3.2 python3.3 python2.6
 

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -16,6 +16,9 @@ cd /home/vagrant || exit
 # get arrow-keys working in terminal (e.g. editing in vi)
 echo 'stty sane' >> ~/.bash_profile
 echo 'export TERM=linux' >> ~/.bash_profile
+
+# Kritika (https://github.com/koalaman/shellcheck/wiki/SC1090)
+# shellcheck source=/dev/null
 source ~/.bash_profile
 
 


### PR DESCRIPTION
**Vagrant / httpretty**

I couldn't get the tests passing with tox. I found it was because httpretty 0.9.* requires Python 2.7.13 or higher, and we only get 2.7.6 from Ubuntu Trusty (14.04.5)

Fixed that by locking our httpretty dependency to 0.8.14 or earlier.

**Project Description**

Followed the example from https://github.com/di/markdown-description-example/blob/master/setup.py for how to do this. Deleted setup.cfg as I don't think we're using it any more.