### PR TITLE
Require pyopenssl and add request backoff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,13 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-    - "3.7"
     - "pypy3"
+
+matrix:
+    include:
+        - python: 3.7
+          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
     - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 git:
   depth: false
 language: python
@@ -6,13 +6,8 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
+    - "3.7"
     - "pypy3"
-
-# matrix:
-#     include:
-#         - python: 3.7
-#           dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-#           sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
     - pip install tox-travis

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 git:
   depth: false
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-    - "pypy3"
+    # - "pypy3" # out of date OpenSSL error
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 git:
   depth: false
 language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
     - "2.7"
     - "3.5"
     - "3.6"
-    - "pypy"
+    - "pypy3"
 
 matrix:
     include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 git:
   depth: false
 language: python
@@ -8,11 +8,11 @@ python:
     - "3.6"
     - "pypy3"
 
-matrix:
-    include:
-        - python: 3.7
-          dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
-          sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
+# matrix:
+#     include:
+#         - python: 3.7
+#           dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+#           sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
 
 install:
     - pip install tox-travis

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,5 +1,6 @@
 v1.2.1 Wed 6 May 2020
   Ensure OpenSSL is available on installation
+  Add exponential backoff to HTTP requests
 
 v1.2 Sun 9 Jun 2019
   Use https as default

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,6 @@
+v1.2.1 Wed 6 May 2020
+  Ensure OpenSSL is available on installation
+
 v1.2 Sun 9 Jun 2019
   Use https as default
   Handle 401 and 403 exceptions

--- a/opencage/__init__.py
+++ b/opencage/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = "OpenCage Data"
 __email__ = 'info@opencagedata.com'
-__version__ = '1.0.0'
+__version__ = '1.2.1'

--- a/opencage/geocoder.py
+++ b/opencage/geocoder.py
@@ -4,9 +4,13 @@ from datetime import datetime
 from decimal import Decimal
 import collections
 
+import os
 import six
 import requests
 import backoff
+
+def backoff_max_time():
+    return int(os.environ.get('BACKOFF_MAX_TIME', '120'))
 
 class OpenCageGeocodeError(Exception):
 
@@ -160,7 +164,10 @@ class OpenCageGeocode(object):
         """
         return self.geocode(_query_for_reverse_geocoding(lat, lng), **kwargs)
 
-    @backoff.on_exception(backoff.expo, UnknownError, max_tries=8, max_time=120)
+    @backoff.on_exception(
+        backoff.expo,
+        (UnknownError),
+        max_tries=5, max_time=backoff_max_time)
     def _opencage_request(self, params):
         response = requests.get(self.url, params=params)
 

--- a/opencage/geocoder.py
+++ b/opencage/geocoder.py
@@ -166,7 +166,7 @@ class OpenCageGeocode(object):
 
     @backoff.on_exception(
         backoff.expo,
-        (UnknownError),
+        (UnknownError, requests.exceptions.RequestException),
         max_tries=5, max_time=backoff_max_time)
     def _opencage_request(self, params):
         response = requests.get(self.url, params=params)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ except FileNotFoundError:
 
 setup(
     name="opencage",
-    version="1.2",
+    version="1.2.1",
     description="Simple wrapper module for the OpenCage Geocoder API",
     long_description=long_description,
     long_description_content_type='text/markdown',
@@ -56,7 +56,7 @@ setup(
     install_requires=[
         'Requests>=2.2.0',
         'six>=1.4.0',
-        'pyopenssl>=16.0.0'
+        'pyopenssl>=0.15.1'
     ],
     test_suite='tests',
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
     install_requires=[
         'Requests>=2.2.0',
         'six>=1.4.0',
+        'pyopenssl>=16.0.0'
     ],
     test_suite='tests',
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(
     install_requires=[
         'Requests>=2.2.0',
         'six>=1.4.0',
-        'pyopenssl>=0.15.1'
+        'pyopenssl>=0.15.1',
+        'backoff>=1.10.0'
     ],
     test_suite='tests',
     tests_require=[

--- a/tests.py
+++ b/tests.py
@@ -6,6 +6,7 @@
 
 import unittest
 
+import os
 import six
 import httpretty
 
@@ -13,6 +14,8 @@ from opencage.geocoder import OpenCageGeocode
 from opencage.geocoder import InvalidInputError, RateLimitExceededError, UnknownError, ForbiddenError, NotAuthorizedError
 from opencage.geocoder import floatify_latlng, _query_for_reverse_geocoding
 
+# reduce maximum backoff retry time from 120s to 1s
+os.environ['BACKOFF_MAX_TIME'] = '1'
 
 class OpenCageGeocodeTestCase(unittest.TestCase):
     def setUp(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py36, pypy3
+envlist = py27, py33, py36, pypy
 
 [testenv]
 commands = {envpython} setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py36, pypy
+envlist = py27, py33, py36, pypy3
 
 [testenv]
 commands = {envpython} setup.py test


### PR DESCRIPTION
I have added a requirement for pyopenssl to the `setup.py`. The version is set to >=0.15.1 because that is the latest version that works with python 2.6 and 3.2 mentioned in the `setup.py` classifiers. pyopenssl 0.15.1 is quite old (April 2015) but I don't think that will be a problem.

I tried installing the pyopenssl pip package in a plain docker container without OpenSSL installed and it failed as expected, so I think it's fair to assume this is all that's needed to ensure OpenSSL is present.