### PR TITLE
Better non-JSON response error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ python:
 - '3.7'
 - '3.8'
 - '3.9'
+- '3.10'
 install:
 - pip install tox-travis
 script:

--- a/Changes.txt
+++ b/Changes.txt
@@ -1,3 +1,7 @@
+v2.1.0 Thu 13 Oct 2022
+  Better handling of non-JSON error responses from API
+  Test on Python 3.10
+
 v2.0.0 Thu 15 Jul 2021
   Python 2 no longer supported
   New geocode_async and reverse_geocode_async methods

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 
 Vagrant.configure("2") do |config|
 
-  config.vm.box = "bento/ubuntu-20.04"
+  config.vm.box = "bento/ubuntu-22.04"
 
   config.vm.synced_folder ".", "/home/vagrant/python-opencage-geocoder"
 

--- a/opencage/geocoder.py
+++ b/opencage/geocoder.py
@@ -240,8 +240,7 @@ class OpenCageGeocode:
         try:
             response_json = response.json()
         except ValueError as e:
-            if response.status_code == 200:
-                raise UnknownError("Non-JSON result from server") from e
+            raise UnknownError("Non-JSON result from server") from e
 
         if response.status_code == 401:
             raise NotAuthorizedError()
@@ -267,8 +266,7 @@ class OpenCageGeocode:
             try:
                 response_json = await response.json()
             except ValueError as e:
-                if response.status == 200:
-                    raise UnknownError("Non-JSON result from server") from e
+                raise UnknownError("Non-JSON result from server") from e
 
             if response.status == 401:
                 raise NotAuthorizedError()

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,14 @@ except FileNotFoundError:
 
 setup(
     name="opencage",
-    version="2.0.0",
+    version="2.1.0",
     description="Wrapper module for the OpenCage Geocoder API",
     long_description=long_description,
     long_description_content_type='text/markdown',
     author="OpenCage GmbH",
     author_email="info@opencagedata.com",
     url="https://github.com/OpenCageData/python-opencage-geocoder/",
-    download_url="https://github.com/OpenCageData/python-opencage-geocoder/tarball/2.0.0",
+    download_url="https://github.com/OpenCageData/python-opencage-geocoder/tarball/2.1.0",
     license="BSD",
     packages=find_packages(),
     include_package_data=True,
@@ -52,6 +52,7 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
         'Topic :: Scientific/Engineering :: GIS',
         'Topic :: Utilities'
     ],
@@ -63,7 +64,7 @@ setup(
     test_suite='tests',
     tests_require=[
         'httpretty>=0.9.6',
-        'pylint>=2.7.2',
+        'pylint==2.9.1',
         'pytest>=6.0'
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3613, py3710, py38, py3920, lint
+envlist = py3613, py3710, py3815, py3920, py3108, lint
 
 [testenv]
 deps =
@@ -12,6 +12,6 @@ commands = pytest test
 usedevelop = True
 deps =
     httpretty
-    pylint
+    pylint==2.9.1
     pytest
 commands = pylint opencage examples/demo.py setup.py test

--- a/vagrant-provision.sh
+++ b/vagrant-provision.sh
@@ -15,7 +15,8 @@ eval "$(pyenv virtualenv-init -)"
 source ~/.bashrc
 exec $SHELL
 
-for VERSION in 3.6.13  3.7.10  3.8.8  3.9.2; do
+for VERSION in 3.6.13  3.7.10  3.8.15  3.9.2  3.10.8; do
+  echo "Installing $VERSION ..."
   pyenv install --skip-existing $VERSION
   pyenv global $VERSION
 done


### PR DESCRIPTION
Version 2.1.0

Fixes "local variable 'response_json' referenced before assignment" error.

The test case for non-JSON responses from the API didn't work as expected. The HTTPretty library was setting a JSON header, one has to use `forcing_headers` to override that.

Also test on Python 3.10