### PR TITLE
Test suite: add pytest-asyncio to enable async tests

### DIFF
--- a/test/test_async.py
+++ b/test/test_async.py
@@ -6,6 +6,7 @@ from opencage.geocoder import ForbiddenError, OpenCageGeocode, AioHttpError
 
 # NOTE: Testing keys https://opencagedata.com/api#testingkeys
 
+@pytest.mark.asyncio
 async def test_success():
     async with OpenCageGeocode('6d0e711d72d74daeb2b0bfd2a5cdfdba') as geocoder:
         results = await geocoder.geocode_async("EC1M 5RF")
@@ -15,6 +16,7 @@ async def test_success():
             for result in results
         )
 
+@pytest.mark.asyncio
 async def test_failure():
     async with OpenCageGeocode('6c79ee8e1ca44ad58ad1fc493ba9542f') as geocoder:
         with pytest.raises(ForbiddenError) as excinfo:
@@ -22,6 +24,7 @@ async def test_failure():
 
         assert str(excinfo.value) == 'Your API key has been blocked or suspended.'
 
+@pytest.mark.asyncio
 async def test_without_async_session():
     geocoder = OpenCageGeocode('4372eff77b8343cebfc843eb4da4ddc4')
 
@@ -30,6 +33,7 @@ async def test_without_async_session():
 
     assert str(excinfo.value) == 'Async methods must be used inside an async context.'
 
+@pytest.mark.asyncio
 async def test_using_non_async_method():
     async with OpenCageGeocode('6d0e711d72d74daeb2b0bfd2a5cdfdba') as geocoder:
         with pytest.raises(AioHttpError) as excinfo:

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     httpretty
     pytest
     pytest-aiohttp
+    pytest-asyncio
 commands = pytest test
 
 [testenv:lint]


### PR DESCRIPTION
This makes sure async test methods are not skipped.

```
async def functions are not natively supported and have been skipped.
You need to install a suitable plugin for your async framework
```