### PR TITLE
pyopenssl no longer needed when requests >= 2.26

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,7 @@ setup(
         'Topic :: Utilities'
     ],
     install_requires=[
-        'Requests>=2.2.0',
-        'pyopenssl>=0.15.1',
+        'Requests>=2.26.0',
         'backoff>=1.10.0'
     ],
     test_suite='pytest',


### PR DESCRIPTION
https://github.com/psf/requests/blob/main/HISTORY.md#2260-2021-07-13 "PyOpenSSL is no longer the recommended secure option for Requests"