### PR TITLE
Added ratelimit headers as class properties

### DIFF
--- a/opencage/geocoder.py
+++ b/opencage/geocoder.py
@@ -277,7 +277,7 @@ class OpenCageGeocode:
             },
             'ratelimit_reset': {
                 'header': 'x-ratelimit-reset',
-                'conversor': lambda v: datetime.fromtimestamp(int(v) / 1e3) if v else self.ratelimit_reset
+                'conversor': lambda v: datetime.fromtimestamp(int(v)) if v else self.ratelimit_reset
             }
         }
 

--- a/test/test_ratelimit_properties.py
+++ b/test/test_ratelimit_properties.py
@@ -42,4 +42,4 @@ def test_rate_limit_properties():
 
     assert geocoder.ratelimit_limit == 2500
     assert geocoder.ratelimit_remaining == 2487
-    assert geocoder.ratelimit_reset == datetime.fromtimestamp(1402185600 / 1e3)
+    assert geocoder.ratelimit_reset == datetime.fromtimestamp(1402185600)


### PR DESCRIPTION
I added three new properties to the _OpenCageGeocode_ class:

- _ratelimit_limit_
- _ratelimit_remaining_
- _ratelimit_reset_

These properties are initialized as None and are populated based on the API response headers. To prevent the code from breaking if the headers are missing or renamed, I implemented the following logic:
```python
headers_keys = {
    'ratelimit_limit': {
        'header': 'x-ratelimit-limit',
        'conversor': lambda v: int(v) if v else self.ratelimit_limit
    },
    'ratelimit_remaining': {
        'header': 'x-ratelimit-remaining',
        'conversor': lambda v: int(v) if v else self.ratelimit_remaining
    },
    'ratelimit_reset': {
        'header': 'x-ratelimit-reset',
        'conversor': lambda v: datetime.fromtimestamp(int(v) / 1e3) if v else self.ratelimit_reset
    }
}

for prop_name, prop_data in headers_keys.items():
    header_value = response.headers.get(prop_data['header'])
    conversor = prop_data['conversor']
    setattr(self, prop_name, conversor(header_value))
```

### Motivation:

I needed to capture this information in another project where I use this package. Since I’m currently not on the paid plan, the rate limit data is not included in the response. However, I thought it would be useful to have these properties available for potential future use if this data becomes available.

### Tests:

I added simple tests for these new properties in the **test/test_ratelimit_properties.py** file to ensure that the changes work as expected.