### PR TITLE
CLI: for reverse, the input column parameters were ignored

### DIFF
--- a/opencage/batch.py
+++ b/opencage/batch.py
@@ -110,10 +110,10 @@ class OpenCageBatchGeocoder():
     async def read_one_line(self, row, row_id):
         warnings = False
 
-        if self.options.command == 'reverse':
-            input_columns = [1, 2]
-        elif self.options.input_columns:
+        if self.options.input_columns:
             input_columns = self.options.input_columns
+        elif self.options.command == 'reverse':
+            input_columns = [1, 2]
         else:
             input_columns = None
 

--- a/test/cli/test_cli_args.py
+++ b/test/cli/test_cli_args.py
@@ -155,3 +155,22 @@ def test_defaults():
     assert args.optional_api_params == {}
     assert args.no_progress is False
     assert args.quiet is False
+
+def test_reverse_input_columns():
+    args = parse_args([
+        "reverse",
+        "--api-key", "12345678901234567890123456789012",
+        "--input", "test/fixtures/input.txt",
+        "--output", "test/fixtures/output.csv"
+    ])
+    assert args.input_columns == [1, 2]
+
+    args = parse_args([
+        "reverse",
+        "--api-key", "12345678901234567890123456789012",
+        "--input", "test/fixtures/input.txt",
+        "--output", "test/fixtures/output.csv",
+        "--input-columns", '2,1'
+    ])
+
+    assert args.input_columns == [2, 1]


### PR DESCRIPTION
Bug: `opencage reverse --input-columns 2,1 [...]` was still selecting columns 1,2.