### PR TITLE
Replace httpretty with responses in tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ setup(
     ],
     test_suite='pytest',
     tests_require=[
-        'httpretty>=1.1.4',
+        'responses>=0.25.7',
         'pylint==2.17.4',
         'pytest>=7.4.0'
     ],

--- a/test/test_all.py
+++ b/test/test_all.py
@@ -3,9 +3,8 @@
 from pathlib import Path
 
 import os
-import httpretty
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 
 # reduce maximum backoff retry time from 120s to 1s
@@ -22,51 +21,54 @@ def _any_result_around(results, lat=None, lon=None):
             return True
     return False
 
-@httprettified
+@responses.activate
 def test_gb_postcode():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body=Path('test/fixtures/uk_postcode.json').read_text(encoding="utf-8")
+        body=Path('test/fixtures/uk_postcode.json').read_text(encoding="utf-8"),
+        status=200
     )
 
     results = geocoder.geocode("EC1M 5RF")
     assert _any_result_around(results, lat=51.5201666, lon=-0.0985142)
 
 
-@httprettified
+@responses.activate
 def test_australia():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body=Path('test/fixtures/mudgee_australia.json').read_text(encoding="utf-8")
+        body=Path('test/fixtures/mudgee_australia.json').read_text(encoding="utf-8"),
+        status=200
     )
 
     results = geocoder.geocode("Mudgee, Australia")
     assert _any_result_around(results, lat=-32.5980702, lon=149.5886383)
 
 
-@httprettified
+@responses.activate
 def test_munster():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body=Path('test/fixtures/muenster.json').read_text(encoding="utf-8")
+        body=Path('test/fixtures/muenster.json').read_text(encoding="utf-8"),
+        status=200
     )
 
     results = geocoder.geocode("Münster")
     assert _any_result_around(results, lat=51.9625101, lon=7.6251879)
 
-@httprettified
+@responses.activate
 def test_donostia():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body=Path('test/fixtures/donostia.json').read_text(encoding="utf-8")
-
+        body=Path('test/fixtures/donostia.json').read_text(encoding="utf-8"),
+        status=200
     )
 
-    results =geocoder.geocode("Donostia")
+    results = geocoder.geocode("Donostia")
     assert _any_result_around(results, lat=43.300836, lon=-1.9809529)
 
     # test that the results are in unicode

--- a/test/test_error_blocked.py
+++ b/test/test_error_blocked.py
@@ -1,19 +1,18 @@
 from pathlib import Path
 
 import pytest
-import httpretty
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 from opencage.geocoder import ForbiddenError
 
 
 geocoder = OpenCageGeocode('2e10e5e828262eb243ec0b54681d699a') # will always return 403
 
-@httprettified
+@responses.activate
 def test_api_key_blocked():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
         body=Path('test/fixtures/403_apikey_disabled.json').read_text(encoding="utf-8"),
         status=403,

--- a/test/test_error_invalid_input.py
+++ b/test/test_error_invalid_input.py
@@ -1,19 +1,19 @@
 import pytest
 
-import httpretty
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 from opencage.geocoder import InvalidInputError
 
 geocoder = OpenCageGeocode('abcde')
 
-@httprettified
+@responses.activate
 def test_must_be_unicode_string():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body='{"results":{}}'
+        body='{"results":{}}',
+        status=200
     )
 
     # Should not give errors

--- a/test/test_error_not_authorized.py
+++ b/test/test_error_not_authorized.py
@@ -1,18 +1,17 @@
 from pathlib import Path
 
-import httpretty
 import pytest
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 from opencage.geocoder import NotAuthorizedError
 
 geocoder = OpenCageGeocode('unauthorized-key')
 
-@httprettified
+@responses.activate
 def test_api_key_not_authorized():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
         body=Path('test/fixtures/401_not_authorized.json').read_text(encoding="utf-8"),
         status=401,

--- a/test/test_error_ratelimit_exceeded.py
+++ b/test/test_error_ratelimit_exceeded.py
@@ -1,34 +1,34 @@
 from pathlib import Path
 
-import httpretty
 import pytest
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 from opencage.geocoder import RateLimitExceededError
 
 geocoder = OpenCageGeocode('abcde')
 
-@httprettified
+@responses.activate
 def test_no_rate_limit():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body=Path('test/fixtures/no_ratelimit.json').read_text(encoding="utf-8")
+        body=Path('test/fixtures/no_ratelimit.json').read_text(encoding="utf-8"),
+        status=200
     )
     # shouldn't raise an exception
     geocoder.geocode("whatever")
 
 
-@httprettified
+@responses.activate
 def test_rate_limit_exceeded():
     # 4372eff77b8343cebfc843eb4da4ddc4 will always return 402
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
         body=Path('test/fixtures/402_rate_limit_exceeded.json').read_text(encoding="utf-8"),
         status=402,
-        adding_headers={
+        headers={
             'X-RateLimit-Limit': '2500',
             'X-RateLimit-Remaining': '0',
             'X-RateLimit-Reset': '1402185600'

--- a/test/test_headers.py
+++ b/test/test_headers.py
@@ -4,9 +4,8 @@ from pathlib import Path
 
 import os
 import re
-import httpretty
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 
 # reduce maximum backoff retry time from 120s to 1s
@@ -16,15 +15,19 @@ geocoder = OpenCageGeocode('abcde', user_agent_comment='OpenCage Test')
 
 user_agent_format = re.compile(r'^opencage-python/[\d\.]+ Python/[\d\.]+ (requests|aiohttp)/[\d\.]+ \(OpenCage Test\)$')
 
-@httprettified
+@responses.activate
 def test_sync():
-    httpretty.register_uri(
-        httpretty.GET,
+    responses.add(
+        responses.GET,
         geocoder.url,
-        body=Path('test/fixtures/uk_postcode.json').read_text(encoding="utf-8")
+        body=Path('test/fixtures/uk_postcode.json').read_text(encoding="utf-8"),
+        status=200
     )
 
     geocoder.geocode("EC1M 5RF")
-    user_agent = httpretty.last_request().headers['User-Agent']
+    
+    # Check the User-Agent header in the most recent request
+    request = responses.calls[-1].request
+    user_agent = request.headers['User-Agent']
 
     assert user_agent_format.match(user_agent) is not None

--- a/test/test_session.py
+++ b/test/test_session.py
@@ -2,10 +2,9 @@
 
 from pathlib import Path
 
-import httpretty
 import pytest
+import responses
 
-from httpretty import httprettified
 from opencage.geocoder import OpenCageGeocode
 from opencage.geocoder import NotAuthorizedError
 
@@ -16,23 +15,24 @@ def _any_result_around(results, lat=None, lon=None):
             return True
     return False
 
-@httprettified
+@responses.activate
 def test_success():
     with OpenCageGeocode('abcde') as geocoder:
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             geocoder.url,
-            body=Path('test/fixtures/uk_postcode.json').read_text(encoding="utf-8")
+            body=Path('test/fixtures/uk_postcode.json').read_text(encoding="utf-8"),
+            status=200
         )
 
         results = geocoder.geocode("EC1M 5RF")
         assert _any_result_around(results, lat=51.5201666, lon=-0.0985142)
 
-@httprettified
+@responses.activate
 def test_failure():
     with OpenCageGeocode('unauthorized-key') as geocoder:
-        httpretty.register_uri(
-            httpretty.GET,
+        responses.add(
+            responses.GET,
             geocoder.url,
             body=Path('test/fixtures/401_not_authorized.json').read_text(encoding="utf-8"),
             status=401,

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ python =
 
 [testenv]
 deps =
-    httpretty
+    responses
     pytest
     pytest-aiohttp
     pytest-asyncio
@@ -22,7 +22,7 @@ commands =
 [testenv:lint]
 usedevelop = True
 deps =
-    httpretty
+    responses
     pylint==2.17.4
     pytest
 commands =


### PR DESCRIPTION
Replaces unmaintained `httpretty` with `responses` for mocking HTTP requests in tests.